### PR TITLE
Fix SyntaxWarning "is with a literal"

### DIFF
--- a/zipper.py
+++ b/zipper.py
@@ -245,7 +245,7 @@ class Loc(namedtuple('Loc', 'current, path, is_branch, get_children, make_node')
     See preorder_iter for an example.
     """
 
-    if self.path is ():
+    if self.path == ():
       return None
 
     n = self.down() or self.right()


### PR DESCRIPTION
When I run this code with Python 3.10, I get this message:

```
/home/swarden/.cache/activestate/89590e42/usr/lib/python3.10/site-packages/zipper.py:248: SyntaxWarning: "is" with a literal. Did you mean "=="?
    if self.path is ():
```

This small syntax change should squelch the warning.